### PR TITLE
Support for stock Samsung Galaxy Note II (Android 4.1.2)

### DIFF
--- a/src/pk/qwerty12/nfclockscreenoffenabler/NFCLockScreenOffEnabler.java
+++ b/src/pk/qwerty12/nfclockscreenoffenabler/NFCLockScreenOffEnabler.java
@@ -24,7 +24,6 @@ import android.content.pm.ResolveInfo;
 import android.content.res.XModuleResources;
 import android.media.SoundPool;
 import android.nfc.NfcAdapter;
-import android.os.UserHandle;
 import android.util.Log;
 import de.robv.android.xposed.IXposedHookCmdInit;
 import de.robv.android.xposed.IXposedHookLoadPackage;
@@ -212,10 +211,17 @@ public class NFCLockScreenOffEnabler implements IXposedHookZygoteInit, IXposedHo
 			} catch (NoSuchMethodError e) {}
 
 			// Doesn't exist on pre-4.2
-			try {
-				findAndHookMethod(ContextImpl, "sendBroadcastAsUser", Intent.class, UserHandle.class, hook);
-				findAndHookMethod(ContextImpl, "sendBroadcastAsUser", Intent.class, UserHandle.class, String.class, hook);
-			} catch (NoSuchMethodError e) {}
+			int currentapiVersion = android.os.Build.VERSION.SDK_INT;
+			if (currentapiVersion >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1){
+				Class<?> UserHandle = findClass("android.os.UserHandle", null);
+
+				if (UserHandle != null) {
+					try {
+						findAndHookMethod(ContextImpl, "sendBroadcastAsUser", Intent.class, UserHandle, hook);
+						findAndHookMethod(ContextImpl, "sendBroadcastAsUser", Intent.class, UserHandle, String.class, hook);
+					} catch (NoSuchMethodError e) {}
+				}
+			}
 		} catch (ClassNotFoundError e) {}
 	}
 

--- a/src/pk/qwerty12/nfclockscreenoffenabler/NFCLockScreenOffEnabler.java
+++ b/src/pk/qwerty12/nfclockscreenoffenabler/NFCLockScreenOffEnabler.java
@@ -628,9 +628,7 @@ public class NFCLockScreenOffEnabler implements IXposedHookZygoteInit, IXposedHo
 			}
 		};
 
-		context.registerReceiver(receiver, new IntentFilter(Common.INTENT_UNLOCK_DEVICE),
-				"android.permission.INTERNAL_SYSTEM_WINDOW", null);
-
+		context.registerReceiver(receiver, new IntentFilter(Common.INTENT_UNLOCK_DEVICE));
 		context.registerReceiver(receiver, new IntentFilter(Common.INTENT_UNLOCK_INTERCEPTED));
 	}
 }

--- a/src/pk/qwerty12/nfclockscreenoffenabler/NfcTags.java
+++ b/src/pk/qwerty12/nfclockscreenoffenabler/NfcTags.java
@@ -19,6 +19,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.nfc.NfcAdapter;
 import android.nfc.Tag;
+import android.nfc.tech.IsoDep;
 import android.nfc.tech.MifareClassic;
 import android.nfc.tech.MifareUltralight;
 import android.nfc.tech.Ndef;
@@ -179,8 +180,11 @@ public class NfcTags extends Activity implements UndoListener {
 			throw new RuntimeException("fail", e);
 		}
 		mIntentFiltersArray = new IntentFilter[] {ndef};
-		mTechListsArray = new String[][] { new String[] { MifareUltralight.class.getName(), Ndef.class.getName(), NfcA.class.getName()},
-				new String[] { MifareClassic.class.getName(), Ndef.class.getName(), NfcA.class.getName()}};
+		mTechListsArray = new String[][] {
+			new String[] { IsoDep.class.getName(), Ndef.class.getName(), NfcA.class.getName()},
+			new String[] { MifareUltralight.class.getName(), Ndef.class.getName(), NfcA.class.getName()},
+			new String[] { MifareClassic.class.getName(), Ndef.class.getName(), NfcA.class.getName()}
+		};
 
 		mAlreadySetup = true;
 	}


### PR DESCRIPTION
I've added support for Samsung TecTiles, which appear to be IsoDep NFC tags. NFCLockscreenoffEnabler now recognizes and adds them to the authorized tags list.

I've reworked the way android.os.UserHandle is pulled in so that NFCLockscreenoffEnable will work with devices running less than Android API 17 (Android 4.2). I don't have an Android 4.2 or higher device to test my changes with, but I think it will do the trick. Based on the way I'm retrieving the class, I think it's appropriate to pass UserHandle and not UserHandle.class in the call to findAndHookMethod().

I've been testing this with my Samsung Galaxy Note II (Verizon SCH-I605), but none of this is actually specific to this device; I just couldn't come up with a better subject for this pull request... :)
